### PR TITLE
Add switches to hyraxctl to enable authentcation

### DIFF
--- a/hyraxctl
+++ b/hyraxctl
@@ -48,6 +48,8 @@ export THREDDS_CATALOG_ROOT="${THREDDS_CATALOG_ROOT:-""}"
 export HYRAX_MEMORY="${HYRAX_MEMORY:-"24g"}"
 export RPM_BUILD_REPO="s3://opendap.travis.build"
 
+export  AUTH_WEB_XML="$HYRAX_HOME/tomcat/web.xml"
+
 export bes_cores_dir
 export tomcat_server_xml
 export run_privileged
@@ -610,6 +612,14 @@ function start_hyrax() {
         return 1
     fi
 
+    local auth_volume=
+    local use_auth_filters="${AUTH_ENABLED:-false}"
+    if $use_auth_filters
+    then
+        loggy "$prolog Enabling authentication filters using web.xml: $AUTH_WEB_XML"
+        auth_volume="--volume $AUTH_WEB_XML:/usr/share/tomcat/webapps/opendap/WEB-INF/web.xml"
+    fi
+
     make_network_as_needed
 
     local use_disconnect="${disconnect:-"-d"}"
@@ -627,7 +637,7 @@ function start_hyrax() {
         --net="$HYRAX_NETWORK" \
         --publish 8009:8009 \
         --publish 8080:8080 \
-        --publish 8443:8443 \
+        --publish 8443:8443 $auth_volume \
         --volume "$data_dir":/usr/share/hyrax:ro \
         --volume "$bes_log_dir":/var/log/bes \
         --volume "$bes_cores_dir":/cores \

--- a/hyraxctl
+++ b/hyraxctl
@@ -49,8 +49,8 @@ export HYRAX_MEMORY="${HYRAX_MEMORY:-"24g"}"
 export RPM_BUILD_REPO="s3://opendap.travis.build"
 
 # uid: 101 gid: 1000
-export BES_UID="$(BES_UID:-101)"
-export BES_GID="$(BES_GID:-1000)"
+export BES_UID="$(BES_UID:-"101")"
+export BES_GID="$(BES_GID:-"1000")"
 
 export AUTH_WEB_XML="${AUTH_WEB_XML:-"$HYRAX_HOME/tomcat/auth_web.xml"}"
 export AUTH_ENABLED="${AUTH_ENABLED:-false}"

--- a/hyraxctl
+++ b/hyraxctl
@@ -470,6 +470,8 @@ function set_file_permissions() {
         loggy "$prolog Waiting $sleep_time seconds for hyrax to get going..."
         sleep $sleep_time
 
+        loggy "$(docker logs "$name")"
+
         local bes_uid
         bes_uid=$(docker logs "$name" 2>&1 | grep bes_uid | awk '{print $2;}')
         loggy "$prolog bes_uid: $bes_uid"

--- a/hyraxctl
+++ b/hyraxctl
@@ -48,6 +48,10 @@ export THREDDS_CATALOG_ROOT="${THREDDS_CATALOG_ROOT:-""}"
 export HYRAX_MEMORY="${HYRAX_MEMORY:-"24g"}"
 export RPM_BUILD_REPO="s3://opendap.travis.build"
 
+# uid: 101 gid: 1000
+export BES_UID="$(BES_UID:-101)"
+export BES_GID="$(BES_GID:-1000)"
+
 export AUTH_WEB_XML="${AUTH_WEB_XML:-"$HYRAX_HOME/tomcat/auth_web.xml"}"
 export AUTH_ENABLED="${AUTH_ENABLED:-false}"
 export bes_cores_dir
@@ -151,6 +155,9 @@ function show_config() {
     loggy "$prolog          HYRAX_NETWORK: $HYRAX_NETWORK"
     loggy "$prolog       HYRAX_DEPLOYMENT: $HYRAX_DEPLOYMENT"
     loggy "$prolog           HYRAX_MEMORY: $HYRAX_MEMORY"
+    loggy "$prolog"
+    loggy "$prolog                BES_UID: $BES_UID"
+    loggy "$prolog                BES_GID: $BES_GID"
     loggy "$prolog"
     loggy "$prolog           AUTH_WEB_XML: $AUTH_WEB_XML"
     loggy "$prolog           AUTH_ENABLED: $AUTH_ENABLED"
@@ -452,42 +459,13 @@ function set_file_permissions() {
     loggy "$prolog BEGIN"
 
     local vers_doc
-    vers_doc=$(which sw_vers)
+    vers_doc=$(which sw_vers 2>&1)
     if test $? -ne 0; then
-        local name="testy_besty"
-
-        local platform=""
-        platform="$(get_platform)"
-        loggy "$prolog platform: $platform"
-
-        local use_disconnect="-d" #
-        loggy "$prolog use_disconnect: $use_disconnect"
-
-        loggy "$prolog Checking bes user info in Hyrax container: $HYRAX_IMAGE"
-        docker run $use_disconnect $platform --name "$name" "$HYRAX_IMAGE"
-
-        local sleep_time=10
-        loggy "$prolog Waiting $sleep_time seconds for hyrax to get going..."
-        sleep $sleep_time
-
-        loggy "$(docker logs "$name")"
-
-        local bes_uid
-        bes_uid=$(docker logs "$name" 2>&1 | grep bes_uid | awk '{print $2;}')
-        loggy "$prolog bes_uid: $bes_uid"
-
-        local bes_gid
-        bes_gid=$(docker logs "$name" 2>&1 | grep bes_gid | awk '{print $2;}')
-        loggy "$prolog bes_gid: $bes_gid"
-
-        loggy "$prolog Stopping Hyrax container: $HYRAX_IMAGE"
-        docker container rm -f "$name"
-
-        if test -n "$bes_uid" && test -n "$bes_gid"; then
-            loggy "$prolog Setting ownership of $bes_log_dir"
-            sudo chown -R "$bes_uid":"$bes_gid" "$bes_log_dir"
+        if test -n "$BES_UID" && test -n "$BES_GID"; then
+            loggy "$prolog Setting ownership of '$bes_log_dir'"
+            sudo chown -R "$BES_UID":"$BES_GID" "$bes_log_dir"
         else
-            loggy "$prolog ERROR - Failed to determine one or both of bes user uid or gid."
+            loggy "$prolog ERROR - Failed to determine one or both of bes user uid or gid. BES_UID: $BES_UID BES_GID: $BES_GID"
             return 1
         fi
     else

--- a/hyraxctl
+++ b/hyraxctl
@@ -463,9 +463,10 @@ function set_file_permissions() {
     if test $? -ne 0; then
         if test -n "$BES_UID" && test -n "$BES_GID"; then
             loggy "$prolog Setting ownership of '$bes_log_dir'"
-            sudo chown -R "$BES_UID":"$BES_GID" "$bes_log_dir"
+            sudo chown -v -R "$BES_UID":"$BES_GID" "$bes_log_dir"
         else
-            loggy "$prolog ERROR - Failed to determine one or both of bes user uid or gid. BES_UID: $BES_UID BES_GID: $BES_GID"
+            loggy "$prolog ERROR - Failed to determine one or both of bes user uid or gid."
+            loggy "$prolog ERROR - Found BES_UID: '$BES_UID' BES_GID: '$BES_GID'"
             return 1
         fi
     else

--- a/hyraxctl
+++ b/hyraxctl
@@ -48,8 +48,8 @@ export THREDDS_CATALOG_ROOT="${THREDDS_CATALOG_ROOT:-""}"
 export HYRAX_MEMORY="${HYRAX_MEMORY:-"24g"}"
 export RPM_BUILD_REPO="s3://opendap.travis.build"
 
-export  AUTH_WEB_XML="$HYRAX_HOME/tomcat/web.xml"
-
+export AUTH_WEB_XML="${AUTH_WEB_XML:-"$HYRAX_HOME/tomcat/auth_web.xml"}"
+export AUTH_ENABLED="${AUTH_ENABLED:-false}"
 export bes_cores_dir
 export tomcat_server_xml
 export run_privileged
@@ -151,6 +151,11 @@ function show_config() {
     loggy "$prolog          HYRAX_NETWORK: $HYRAX_NETWORK"
     loggy "$prolog       HYRAX_DEPLOYMENT: $HYRAX_DEPLOYMENT"
     loggy "$prolog           HYRAX_MEMORY: $HYRAX_MEMORY"
+    loggy "$prolog"
+    loggy "$prolog           AUTH_WEB_XML: $AUTH_WEB_XML"
+    loggy "$prolog           AUTH_ENABLED: $AUTH_ENABLED"
+    loggy "$prolog"
+    loggy "$prolog"
     loggy "$prolog"
     loggy "$prolog-- Values derived from primary values: "
     loggy "$prolog"

--- a/hyraxctl
+++ b/hyraxctl
@@ -49,8 +49,8 @@ export HYRAX_MEMORY="${HYRAX_MEMORY:-"24g"}"
 export RPM_BUILD_REPO="s3://opendap.travis.build"
 
 # uid: 101 gid: 1000
-export BES_UID="$(BES_UID:-"101")"
-export BES_GID="$(BES_GID:-"1000")"
+export BES_UID="${BES_UID:-"101"}"
+export BES_GID="${BES_GID:-"1000"}"
 
 export AUTH_WEB_XML="${AUTH_WEB_XML:-"$HYRAX_HOME/tomcat/auth_web.xml"}"
 export AUTH_ENABLED="${AUTH_ENABLED:-false}"


### PR DESCRIPTION
This change also stops starting the server and checking to docker log to determine the BES UID and GIS> Instead they are set to like this:
```
export BES_UID="${BES_UID:-"101"}"
export BES_GID="${BES_GID:-"1000"}"
```
So they can be easily overridden as needed.
